### PR TITLE
Buggy

### DIFF
--- a/components/test-page-utils.js
+++ b/components/test-page-utils.js
@@ -329,10 +329,10 @@ export function clearState(state, keys) {
 
 export function handleResult(state, keys) {
   return function (result, memResult) {
+    if (state.weak.resultHandler(result, memResult)) {
+      console.log(result);
+    }
     for (const key of keys) {
-      if (state.weak.resultHandler(result, memResult)) {
-        console.log(result);
-      }
       if (state[key].resultHandler(result, memResult)) {
         state[key].internalState = state[key].internalState + 1;
         state[key].throttledUpdate(state[key].internalState);

--- a/components/test-page-utils.js
+++ b/components/test-page-utils.js
@@ -330,6 +330,9 @@ export function clearState(state, keys) {
 export function handleResult(state, keys) {
   return function (result, memResult) {
     for (const key of keys) {
+      if (state.weak.resultHandler(result, memResult)) {
+        console.log(result);
+      }
       if (state[key].resultHandler(result, memResult)) {
         state[key].internalState = state[key].internalState + 1;
         state[key].throttledUpdate(state[key].internalState);

--- a/pages/tests/corr4.js
+++ b/pages/tests/corr4.js
@@ -5,6 +5,7 @@ import coRR4 from '../../shaders/corr4.wgsl';
 import coRR4_RMW from '../../shaders/corr4-rmw.wgsl';
 import coRR4_workgroup from '../../shaders/corr4-workgroup.wgsl';
 import coRR4_workgroup_buggy from '../../shaders/corr4-workgroup-buggy.wgsl';
+import coRR4_workgroup_buggy1 from '../../shaders/corr4-workgroup-buggy1.wgsl';
 import coRR4_RMW_workgroup from '../../shaders/corr4-rmw-workgroup.wgsl';
 
 const testParams = JSON.parse(JSON.stringify(defaultTestParams));
@@ -34,7 +35,12 @@ const variants = {
 3.2: let r3 = atomicLoad(x)`], true),
     shader: coRR4_workgroup_buggy
   },
-
+  workgroup_buggy1: {
+    pseudo: buildPseudoCode([`0.1: atomicStore(x, 1)`, `1.1: let r0 = atomicLoad(x)
+1.2: let r1 = atomicLoad(x)`, `2.1: atomicStore(x, 2)`, `3.1: let r2 = atomicLoad(x)
+3.2: let r3 = atomicLoad(x)`], true),
+    shader: coRR4_workgroup_buggy1
+  },
   workgroup_rmw: {
     pseudo: buildPseudoCode([`0.1: atomicExchange(x, 1)`, `1.1: let r0 = atomicLoad(x)
 1.2: let r1 = atomicAdd(x, 0)`, `2.1: atomicExchange(x, 2)`, `3.1: let r2= atomicLoad(x)

--- a/pages/tests/corr4.js
+++ b/pages/tests/corr4.js
@@ -4,6 +4,7 @@ import { TestSetupPseudoCode, buildPseudoCode} from '../../components/testPseudo
 import coRR4 from '../../shaders/corr4.wgsl';
 import coRR4_RMW from '../../shaders/corr4-rmw.wgsl';
 import coRR4_workgroup from '../../shaders/corr4-workgroup.wgsl';
+import coRR4_workgroup_buggy from '../../shaders/corr4-workgroup-buggy.wgsl';
 import coRR4_RMW_workgroup from '../../shaders/corr4-rmw-workgroup.wgsl';
 
 const testParams = JSON.parse(JSON.stringify(defaultTestParams));
@@ -27,6 +28,13 @@ const variants = {
 3.2: let r3 = atomicLoad(x)`], true),
     shader: coRR4_workgroup
   },
+  workgroup_buggy: {
+    pseudo: buildPseudoCode([`0.1: atomicStore(x, 1)`, `1.1: let r0 = atomicLoad(x)
+1.2: let r1 = atomicLoad(x)`, `2.1: atomicStore(x, 2)`, `3.1: let r2 = atomicLoad(x)
+3.2: let r3 = atomicLoad(x)`], true),
+    shader: coRR4_workgroup_buggy
+  },
+
   workgroup_rmw: {
     pseudo: buildPseudoCode([`0.1: atomicExchange(x, 1)`, `1.1: let r0 = atomicLoad(x)
 1.2: let r1 = atomicAdd(x, 0)`, `2.1: atomicExchange(x, 2)`, `3.1: let r2= atomicLoad(x)
@@ -37,7 +45,7 @@ const variants = {
 
 export default function CoRR4() {
   testParams.memoryAliases[1] = 0;
-  testParams.numOutputs = 4;
+  testParams.numOutputs = 8;
   const pseudoCode = {
     setup: <TestSetupPseudoCode init="*x = 0" finalState="(r0 == 1 && r1 == 2 && r2 == 2 && r3 == 1) || (r0 == 2 && r1 == 1 && r2 == 1 && r3 == 2) || (r0 != 0 && r1 == 0) || (r2 != 0 && r3 == 0)"/>,
     code: variants.default.pseudo

--- a/pages/tests/corr4.js
+++ b/pages/tests/corr4.js
@@ -45,7 +45,7 @@ const variants = {
 
 export default function CoRR4() {
   testParams.memoryAliases[1] = 0;
-  testParams.numOutputs = 8;
+  testParams.numOutputs = 5;
   const pseudoCode = {
     setup: <TestSetupPseudoCode init="*x = 0" finalState="(r0 == 1 && r1 == 2 && r2 == 2 && r3 == 1) || (r0 == 2 && r1 == 1 && r2 == 1 && r3 == 2) || (r0 != 0 && r1 == 0) || (r2 != 0 && r3 == 0)"/>,
     code: variants.default.pseudo

--- a/shaders/corr4-workgroup-buggy.wgsl
+++ b/shaders/corr4-workgroup-buggy.wgsl
@@ -105,8 +105,8 @@ let workgroupXSize = 256;
     }
     let r0 = atomicLoad(ax);
     let r1 = atomicLoad(ay);
-    results.value[0] = r0;
     results.value[1] = r1;
+    results.value[0] = r0;
   } elseif (shuffled_ids.value[global_invocation_id[0]] == 2u) {
     if (mem_stress == 1u) {
       do_stress(stress_params.value[5], stress_params.value[6], workgroup_id[0]);

--- a/shaders/corr4-workgroup-buggy.wgsl
+++ b/shaders/corr4-workgroup-buggy.wgsl
@@ -105,8 +105,8 @@ let workgroupXSize = 256;
     }
     let r0 = atomicLoad(ax);
     let r1 = atomicLoad(ay);
-    results.value[1] = r1;
     results.value[0] = r0;
+    results.value[1] = r1;
   } elseif (shuffled_ids.value[global_invocation_id[0]] == 2u) {
     if (mem_stress == 1u) {
       do_stress(stress_params.value[5], stress_params.value[6], workgroup_id[0]);
@@ -124,6 +124,9 @@ let workgroupXSize = 256;
     }
     let r2 = atomicLoad(ax);
     let r3 = atomicLoad(ay);
+    if (r2 != 0u && r3 == 0u) {
+      results.value[4] = 1u;
+    }
     results.value[2] = r2;
     results.value[3] = r3;
     } elseif (stress_params.value[1] == 1u) {  

--- a/shaders/corr4-workgroup-buggy1.wgsl
+++ b/shaders/corr4-workgroup-buggy1.wgsl
@@ -1,0 +1,132 @@
+[[block]] struct AtomicMemory {
+  value: array<atomic<u32>>;
+};
+[[block]] struct Memory {
+  value: array<u32>;
+};
+
+[[block]] struct StressParamsMemory {
+  value: [[stride(16)]] array<u32, 7>;
+};
+
+[[group(0), binding(0)]] var<storage, read_write> test_data : Memory;
+[[group(0), binding(1)]] var<storage, read_write> atomic_test_data : AtomicMemory;
+[[group(0), binding(2)]] var<storage, read_write> mem_locations : Memory;
+[[group(0), binding(3)]] var<storage, read_write> results : Memory;
+[[group(0), binding(4)]] var<storage, read_write> shuffled_ids : Memory;
+[[group(0), binding(5)]] var<storage, read_write> barrier : AtomicMemory;
+[[group(0), binding(6)]] var<storage, read_write> scratchpad : Memory;
+[[group(0), binding(7)]] var<storage, read_write> scratch_locations : Memory;
+[[group(0), binding(8)]] var<uniform> stress_params : StressParamsMemory;
+
+var<workgroup> workgroup_test_data: array<atomic<u32>, 2048>;
+
+fn spin() {
+  var i : u32 = 0u;
+  var bar_val : u32 = atomicAdd(&barrier.value[0], 1u);
+  loop {
+    if (i == 1024u || bar_val >= 4u) {
+      break;
+    }
+    bar_val = atomicAdd(&barrier.value[0], 0u);
+    i = i + 1u;
+  }
+}
+
+fn do_stress(iterations: u32, pattern: u32, workgroup_id: u32) {
+  let addr = scratch_locations.value[workgroup_id];
+  switch(pattern) {
+    case 0u: {
+      for(var i: u32 = 0u; i < iterations; i = i + 1u) {
+        scratchpad.value[addr] = i;
+        scratchpad.value[addr] = i + 1u;
+      }
+    }
+    case 1u: {
+      for(var i: u32 = 0u; i < iterations; i = i + 1u) {
+        scratchpad.value[addr] = i;
+        let tmp1: u32 = scratchpad.value[addr];
+        if (tmp1 > 100000u) {
+          scratchpad.value[addr] = i;
+          break;
+        }
+      }
+    }
+    case 2u: {
+      for(var i: u32 = 0u; i < iterations; i = i + 1u) {
+        let tmp1: u32 = scratchpad.value[addr];
+        if (tmp1 > 100000u) {
+          scratchpad.value[addr] = i;
+          break;
+        }
+        scratchpad.value[addr] = i;
+      }
+    }
+    case 3u: {
+      for(var i: u32 = 0u; i < iterations; i = i + 1u) {
+        let tmp1: u32 = scratchpad.value[addr];
+        if (tmp1 > 100000u) {
+          scratchpad.value[addr] = i;
+          break;
+        }
+        let tmp2: u32 = scratchpad.value[addr];
+        if (tmp2 > 100000u) {
+          scratchpad.value[addr] = i;
+          break;
+        }
+      }
+    }
+    default: {
+      break;
+    }
+  }
+}
+
+let workgroupXSize = 256;
+[[stage(compute), workgroup_size(workgroupXSize)]] fn main([[builtin(workgroup_id)]] workgroup_id : vec3<u32>, [[builtin(global_invocation_id)]] global_invocation_id : vec3<u32>, [[builtin(local_invocation_index)]] local_invocation_index : u32) {
+  let mem_stress = stress_params.value[4];
+  let do_barrier = stress_params.value[0];
+  let ax = &workgroup_test_data[mem_locations.value[0]];
+  let ay = &workgroup_test_data[mem_locations.value[1]];
+  if (shuffled_ids.value[global_invocation_id[0]] == 0u) {
+    if (mem_stress == 1u) {
+      do_stress(stress_params.value[5], stress_params.value[6], workgroup_id[0]);
+    }
+    if (do_barrier == 1u) {
+      spin();
+    }
+    atomicStore(ax, 1u);
+  } elseif (shuffled_ids.value[global_invocation_id[0]] == 1u) {
+    if (mem_stress == 1u) {
+      do_stress(stress_params.value[5], stress_params.value[6], workgroup_id[0]);
+    }
+    if (do_barrier == 1u) {
+      spin();
+    }
+    let r0 = atomicLoad(ax);
+    let r1 = atomicLoad(ay);
+    results.value[0] = r0;
+    results.value[1] = r1;
+  } elseif (shuffled_ids.value[global_invocation_id[0]] == 2u) {
+    if (mem_stress == 1u) {
+      do_stress(stress_params.value[5], stress_params.value[6], workgroup_id[0]);
+    }
+    if (do_barrier == 1u) {
+      spin();
+    }
+    atomicStore(ax, 2u);
+  } elseif (shuffled_ids.value[global_invocation_id[0]] == 3u) {
+    if (mem_stress == 1u) {
+      do_stress(stress_params.value[5], stress_params.value[6], workgroup_id[0]);
+    }
+    if (do_barrier == 1u) {
+      spin();
+    }
+    let r2 = atomicLoad(ax);
+    let r3 = atomicLoad(ay);
+    results.value[3] = r3;
+    results.value[2] = r2;
+    } elseif (stress_params.value[1] == 1u) {  
+    do_stress(stress_params.value[2], stress_params.value[3], workgroup_id[0]);  
+  }
+}


### PR DESCRIPTION
Adds a shader that showcases a potential bug in corr4, running on workgroup memory.

There are two ways the bug manifests (at least on my GPU, an Intel iris integrated running on OSX).

1.) The final read (r3) returns 0, while the penultimate read (r2) does not, which should not be allowed under coherence.

2.) Reads r2 and r3 return a flipped order from r0 and r1, which should also not be allowed. This is much rarer.

Interestingly, the bug only shows up under a modified shader, both of which are included in this PR. The modifications that lead to the bug are:

1.) Flipping the order the read results are written to the results array. For example, instead of writing r2 and then r3, writing r3 and then r2 leads to the bug appearing. The first buggy variant shows this in action.

2.) Adding a conditional statement before writing the read results to the results array. In effect, this is checking the post condition within the gpu, to avoid the possibility of a bug where concurrent accesses to separate memory locations of the same array somehow end up racing. The second buggy variant shows this in action.